### PR TITLE
Add datastore latency logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 gchaos: Chaos Module for Google App Engine 
 ==========================================
 
-Injects hooks around google app engine stubs to trigger errors. In the future
-we hope to support latency adjustments, straight patching, tracing actions, etc.
+Injects hooks around google app engine stubs to trigger errors and latency spikes. 
+In the future we hope to support straight patching, tracing actions, etc.
 
 Currently there is a configuration done in a python module in 
 `gchaos/config/datastore.py` that is the default config. You can override this
@@ -20,11 +20,15 @@ host.
 
 ``` python
 CONFIG = {
-    'enabled': Bool,
-    'errors': {
-        str: ([str], float),
-    },
-    'latency': None
+    'datastore': {
+        'enabled': Bool,
+        'errors': (Bool, {
+            str: ([str], float),
+        }),
+        'latency': (Bool, {
+            str: ([str], float),
+        })
+    }
 }
 ```
 
@@ -32,26 +36,76 @@ CONFIG = {
 
 ``` python
 CONFIG = {
-    'enabled': True,
-    'errors': {
-        "DELETE": (
-            { gchoas.utils.full_name(google.appengine.api.datastore_errors.BadValueError): 1 }, 
-            0.05
-        ),
-        "GET": ({ 'google.appengine.api.datastore_errors.Timeout': 1 }, 0.01),
-        "PUT": (
-            { 'google.appengine.api.datastore_errors.BadRequestError': 0.75
-              'google.appengine.api.datastore_errors.InternalError': 0.25
-            },
-            0.02
-        ),
-    },
-    'latency': None
+    'datastore': {
+        'enabled': True,
+        'errors': (True, {
+            "DELETE": (
+                { gchaos.utils.full_name(google.appengine.api.datastore_errors.BadValueError): 1 }, 
+                0.05
+            ),
+            "GET": ({ 'google.appengine.api.datastore_errors.Timeout': 1 }, 0.01),
+            "PUT": (
+                { 'google.appengine.api.datastore_errors.BadRequestError': 0.75
+                'google.appengine.api.datastore_errors.InternalError': 0.25
+                },
+                0.02
+            ),
+        }),
+        'latency': (True, {
+            "DELETE": ( (500, 1000), 0.05),
+            "GET": ( (1500,), 0.05),
+            "PUT": ( 2500, 0.05)
+            ),
+        })
+    }
 }
 ```
 
-The list of supported Google Datastore errors can be found here:
+You can disable the entire datastore configuration. If you set the `enabled` flag
+to `False` nothing will happer. If it's set to true it will then look for errors
+and latency configrations when it hits a support actions.
+
+There are 3 datastore action types. `DELETE`, `GET`, `PUT`. You can configure different
+rates which trigger the likely hood of either an error latency spike being hit.
+For example above the `DELETE` error rate is set to `0.05`. The minimum is `0.00`
+which means nothing will happen. Where the maximum is `1.00` which means an error
+or latency spike is guranteed to happen. Otherwise it is just probabistic. Also
+each action is independent of the previous action. Meaning that we don't increase
+or decrease the likelyhood of an action being trigger based off subsequent actions.
+
+##### Errors
+
+To configure errors you create a dicionary of errors with the key being a datastore
+error path. This must be a string. So you can either add the full path as a string
+or if you're configuring with python you can import the error directly and use
+our provided `gchaos.utils.full_name` function to get the string version.  The 
+list of supported Google Datastore errors can be found here:
 `google-cloud-sdk/platform/google_appengine/google/appengine/api/datastore_errors.py`
+
+For each entry in the dictionary you then add a corresponding integer for the
+error to be hit. The entries should add up to 100. This way you can say a specific
+error should have a 50% likely hood of being hit by setting it's value to `50`
+while you set the other two to `25` and `25` to give them a 25% chance of firing.
+
+##### Latency
+
+To configure latency you once again add an entry for each action. These entries
+are a tuple (or list if json|yaml). The second value is the probability of the 
+latency triggering. The first value of the tuple is the actual time you want
+the latency spike to last for. This is tracked in millisecond (1000 milliseconds
+equals 1 second). This accepts 3 types of values. Just an integer. So above
+the `PUT` latency action is set to `2500` so the spike will last `2.5` seconds.
+You can also provide a tuple. If the tuple only has a single value then it will
+work just as if you gave us the direct integer not wrapped in the tuple. So above
+the `GET` latency action has `(1500,)` set so the spike with last `1.5` seconds.
+The third option is to add two entries to the tuple. This gives you a range of
+latencies that we will pick a random number between. So above the `DELETE` latency
+action is set to `(500, 1000)`. This means a number between `500` and `1000` will
+be randomly accepted. So for example you could end up with `700` or `0.7` seconds
+with this configuration. Note the second entry must be larger than the first
+otherwise an error will be raised at runtime (we may move this to app initialization
+time in the future). Also there can only be 1 or 2 entries in the list. Any more
+or less and an error will be raised.
 
 ### Install
 
@@ -68,7 +122,7 @@ TODO: Add pip install instructions once pushed to pypi
 
 ### Usage
 
-Once you have gchoas installed and you've modiified the config to your liking
+Once you have gchaos installed and you've modiified the config to your liking
 you add these 2 lines to the end of your file that creates the wsgi app that
 you setup.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ CONFIG = {
             ),
             "GET": ({ 'google.appengine.api.datastore_errors.Timeout': 1 }, 0.01),
             "PUT": (
-                { 'google.appengine.api.datastore_errors.BadRequestError': 0.75
+                { 'google.appengine.api.datastore_errors.BadRequestError': 0.75,
                 'google.appengine.api.datastore_errors.InternalError': 0.25
                 },
                 0.02
@@ -62,7 +62,7 @@ CONFIG = {
 ```
 
 You can disable the entire datastore configuration. If you set the `enabled` flag
-to `False` nothing will happer. If it's set to true it will then look for errors
+to `False` nothing will happen. If it's set to true it will then look for errors
 and latency configrations when it hits a support actions.
 
 There are 3 datastore action types. `DELETE`, `GET`, `PUT`. You can configure different
@@ -71,7 +71,7 @@ For example above the `DELETE` error rate is set to `0.05`. The minimum is `0.00
 which means nothing will happen. Where the maximum is `1.00` which means an error
 or latency spike is guranteed to happen. Otherwise it is just probabistic. Also
 each action is independent of the previous action. Meaning that we don't increase
-or decrease the likelyhood of an action being trigger based off subsequent actions.
+or decrease the likelyhood of an action being triggered based off subsequent actions.
 
 ##### Errors
 
@@ -84,7 +84,7 @@ list of supported Google Datastore errors can be found here:
 
 For each entry in the dictionary you then add a corresponding integer for the
 error to be hit. The entries should add up to 100. This way you can say a specific
-error should have a 50% likely hood of being hit by setting it's value to `50`
+error should have a 50% probability of being hit by setting it's value to `50`
 while you set the other two to `25` and `25` to give them a 25% chance of firing.
 
 ##### Latency

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ TODOS
   - [x] Default config off common error patterns
     - [x] Verify errors are still accurate
     - [x] Add reference to sdk file(s) with errors
-  - [ ] Latency spikes
+  - [x] Latency spikes
   - [ ] Hot key / entity monitoring
   - [ ] Entity type pattern matching
   - [ ] Key pattern matching

--- a/gchaos/chance.py
+++ b/gchaos/chance.py
@@ -48,5 +48,4 @@ def _get_chance():
     Return:
         int
     """
-    random.seed()
     return random.random()

--- a/gchaos/chance.py
+++ b/gchaos/chance.py
@@ -20,19 +20,33 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import logging
+import random
 
-from gchaos.gae.datastore.hook import install_hook
 
-
-def install_datastore_hooks(config):
-    """Install the datastore hooks with the configured configs if the datastore
-    config is enabled.
+def roll(value):
+    """Returns True if the past in value is greather than the random chance that
+    we compute via the random module.
 
     Args:
-        config (gchaos.gae.config.hydrate.DatastoreConfig): Datastore Configuration
+        value (float): The value to compare to. It should be between
+                      (0.00 and 1.00)
 
     Return:
-        None
+        bool
     """
-    if config.enabled:
-        install_hook(config)
+    chance = _get_chance()
+
+    logging.info("RATE {0} AND CHANCE {1}".format(value, chance))
+
+    return value >= chance
+
+
+def _get_chance():
+    """Generate a random number and return it.
+
+    Return:
+        int
+    """
+    random.seed()
+    return random.random()

--- a/gchaos/config/datastore.py
+++ b/gchaos/config/datastore.py
@@ -61,6 +61,33 @@ PUT_ERRORS = {
     full_name(datastore_errors.Timeout): 80,
 }
 
+DEFAULT_LATENCY = (500, 10000)
+DELETE_LATENCY_RATE = 0.05
+GET_LATENCY_RATE = 0.01
+PUT_LATENCY_RATE = 0.02
+
+DELETE_LATENCY = {
+    full_name(datastore_errors.BadValueError): DEFAULT_LATENCY,
+    full_name(datastore_errors.BadRequestError): DEFAULT_LATENCY,
+    full_name(datastore_errors.InternalError): DEFAULT_LATENCY,
+    full_name(datastore_errors.Timeout): DEFAULT_LATENCY,
+}
+
+GET_LATENCY = {
+    full_name(datastore_errors.BadValueError): DEFAULT_LATENCY,
+    full_name(datastore_errors.BadRequestError): DEFAULT_LATENCY,
+    full_name(datastore_errors.EntityNotFoundError): DEFAULT_LATENCY,  # ERROR IS DEPRECATED
+    full_name(datastore_errors.InternalError): DEFAULT_LATENCY,
+    full_name(datastore_errors.Timeout): DEFAULT_LATENCY,
+}
+
+PUT_LATENCY = {
+    full_name(datastore_errors.BadValueError): DEFAULT_LATENCY,
+    full_name(datastore_errors.BadRequestError): DEFAULT_LATENCY,
+    full_name(datastore_errors.InternalError): DEFAULT_LATENCY,
+    full_name(datastore_errors.Timeout): DEFAULT_LATENCY,
+}
+
 # Wrap it all up into the CONFIG variable
 CONFIG = {
     'enabled': True,
@@ -69,7 +96,11 @@ CONFIG = {
         GET: (GET_ERRORS, GET_ERROR_RATE),
         PUT: (PUT_ERRORS, PUT_ERROR_RATE),
     },
-    'latency': None
+    'latency': {
+        DELETE: (DELETE_LATENCY, DELETE_LATENCY_RATE),
+        GET: (GET_LATENCY, GET_LATENCY_RATE),
+        PUT: (PUT_LATENCY, PUT_LATENCY_RATE),
+    }
 }
 
 # Place CONFIG in the list of publically available variables

--- a/gchaos/config/datastore.py
+++ b/gchaos/config/datastore.py
@@ -66,41 +66,19 @@ DELETE_LATENCY_RATE = 0.05
 GET_LATENCY_RATE = 0.01
 PUT_LATENCY_RATE = 0.02
 
-DELETE_LATENCY = {
-    full_name(datastore_errors.BadValueError): DEFAULT_LATENCY,
-    full_name(datastore_errors.BadRequestError): DEFAULT_LATENCY,
-    full_name(datastore_errors.InternalError): DEFAULT_LATENCY,
-    full_name(datastore_errors.Timeout): DEFAULT_LATENCY,
-}
-
-GET_LATENCY = {
-    full_name(datastore_errors.BadValueError): DEFAULT_LATENCY,
-    full_name(datastore_errors.BadRequestError): DEFAULT_LATENCY,
-    full_name(datastore_errors.EntityNotFoundError): DEFAULT_LATENCY,  # ERROR IS DEPRECATED
-    full_name(datastore_errors.InternalError): DEFAULT_LATENCY,
-    full_name(datastore_errors.Timeout): DEFAULT_LATENCY,
-}
-
-PUT_LATENCY = {
-    full_name(datastore_errors.BadValueError): DEFAULT_LATENCY,
-    full_name(datastore_errors.BadRequestError): DEFAULT_LATENCY,
-    full_name(datastore_errors.InternalError): DEFAULT_LATENCY,
-    full_name(datastore_errors.Timeout): DEFAULT_LATENCY,
-}
-
 # Wrap it all up into the CONFIG variable
 CONFIG = {
     'enabled': True,
-    'errors': {
+    'errors': (True, {
         DELETE: (DELETE_ERRORS, DELETE_ERROR_RATE),
         GET: (GET_ERRORS, GET_ERROR_RATE),
         PUT: (PUT_ERRORS, PUT_ERROR_RATE),
-    },
-    'latency': {
-        DELETE: (DELETE_LATENCY, DELETE_LATENCY_RATE),
-        GET: (GET_LATENCY, GET_LATENCY_RATE),
-        PUT: (PUT_LATENCY, PUT_LATENCY_RATE),
-    }
+    }),
+    'latency': (True, {
+        DELETE: (DEFAULT_LATENCY, DELETE_LATENCY_RATE),
+        GET: (DEFAULT_LATENCY, GET_LATENCY_RATE),
+        PUT: (DEFAULT_LATENCY, PUT_LATENCY_RATE),
+    })
 }
 
 # Place CONFIG in the list of publically available variables

--- a/gchaos/config/hydrate.py
+++ b/gchaos/config/hydrate.py
@@ -26,7 +26,8 @@ from gchaos.gae.datastore.actions import ACTIONS
 
 
 DEFAULT_ERROR_ENTRY = ({}, 0.00)
-DEFAULT_LATENCY_ENTRY = ({}, 0.00)
+DEFAULT_LATENCY_ENTRY = (None, 0.00)
+DEFAULT_CONFIG = (False, {})
 
 
 class ChaosConfig(object):
@@ -64,31 +65,35 @@ class DatastoreConfig(object):
             config (dict): Dictionary of a Datastore Configuration
         """
         self.enabled = config.get('enabled', False)
-        self.errors = ErrorsConfig(config.get('errors', {}))
-        self.latency = LatenciesConfig(config.get('latency', {}))
+        self.errors = ErrorsConfig(*config.get('errors', DEFAULT_CONFIG))
+        self.latency = LatenciesConfig(*config.get('latency', DEFAULT_CONFIG))
 
 
 class ErrorsConfig(object):
     """Datastore errors configuration object.
 
     Properties:
+        enabled (bool): Flag for enabling
         delete_errors (ErrorConfig): Delete error configuration
         get_errors (ErrorConfig): Get error configuration
         put_errors (ErrorConfig): Put error configuration
     """
 
-    def __init__(self, config):
+    def __init__(self, enabled, config):
         """Initlialize the ErrorsConfig object setting the delete_errors,
         get_errors and put_errors to an ErrorConfig generated off the passed in
         config.
 
         Args:
+            enabled (bool): Flag for enabling
             config (dict): Dictionary of a Datastore Errors Configuration
         """
+        self.enabled = enabled
         self.delete_errors = ErrorConfig(
             *config.get("DELETE", DEFAULT_ERROR_ENTRY))
         self.get_errors = ErrorConfig(*config.get("GET", DEFAULT_ERROR_ENTRY))
         self.put_errors = ErrorConfig(*config.get("PUT", DEFAULT_ERROR_ENTRY))
+        # self.enabled =
 
     def get_by_action(self, action):
         """Return the corresponding ErrorConfig for the action passed in.
@@ -132,19 +137,23 @@ class LatenciesConfig(object):
     """Datastore latencies configuration object.
 
     Properties:
+        enabled (bool): Flag for enabling
         delete_latencies (LatencyConfig): Delete latency configuration
         get_latencies (LatencyConfig): Get latency configuration
         put_latencies (LatencyConfig): Put latency configuration
     """
 
-    def __init__(self, config):
+    def __init__(self, enabled, config):
         """Initlialize the LatenciesConfig object setting the delete_latencies,
         get_latencies and put_latencies to a LatencyConfig generated off the
         passed in config.
 
         Args:
+            enabled (bool): Flag for enabling
             config (dict): Dictionary of a Datastore Latencies Configuration
         """
+        self.enabled = enabled
+
         self.delete_latencies = LatencyConfig(
             *config.get("DELETE", DEFAULT_LATENCY_ENTRY))
 
@@ -179,15 +188,16 @@ class LatencyConfig(object):
         latency_rate (float): Latency Rate (should be between 0.00 and 1.00)
     """
 
-    def __init__(self, latencies, latency_rate):
+    def __init__(self, latency, latency_rate):
         """Initialize the LatencyConfig object setting the latencies and
         latency_rate to the passed in values. The latencies are converted to a
         Choice object.
 
         Args:
-            latencies (dict): Dictionary of choices (keys) and propability
-                              weights (values)
+            latency (tuple): A tuple that is the range of a latency spike to
+                             pic from. The second value can be ignored to just
+                             use a constant rate.
             latency_rate (float): Latency rate value between 0.00 and 1.00
         """
-        self.latencies = Choice(latencies.values(), latencies.keys())
+        self.latency = latency
         self.latency_rate = latency_rate

--- a/gchaos/config/hydrate.py
+++ b/gchaos/config/hydrate.py
@@ -26,6 +26,7 @@ from gchaos.gae.datastore.actions import ACTIONS
 
 
 DEFAULT_ERROR_ENTRY = ({}, 0.00)
+DEFAULT_LATENCY_ENTRY = ({}, 0.00)
 
 
 class ChaosConfig(object):
@@ -64,7 +65,7 @@ class DatastoreConfig(object):
         """
         self.enabled = config.get('enabled', False)
         self.errors = ErrorsConfig(config.get('errors', {}))
-        self.latency = None
+        self.latency = LatenciesConfig(config.get('latency', {}))
 
 
 class ErrorsConfig(object):
@@ -125,3 +126,68 @@ class ErrorConfig(object):
         """
         self.errors = Choice(errors.values(), errors.keys())
         self.error_rate = error_rate
+
+
+class LatenciesConfig(object):
+    """Datastore latencies configuration object.
+
+    Properties:
+        delete_latencies (LatencyConfig): Delete latency configuration
+        get_latencies (LatencyConfig): Get latency configuration
+        put_latencies (LatencyConfig): Put latency configuration
+    """
+
+    def __init__(self, config):
+        """Initlialize the LatenciesConfig object setting the delete_latencies,
+        get_latencies and put_latencies to a LatencyConfig generated off the
+        passed in config.
+
+        Args:
+            config (dict): Dictionary of a Datastore Latencies Configuration
+        """
+        self.delete_latencies = LatencyConfig(
+            *config.get("DELETE", DEFAULT_LATENCY_ENTRY))
+
+        self.get_latencies = LatencyConfig(
+            *config.get("GET", DEFAULT_LATENCY_ENTRY))
+
+        self.put_latencies = LatencyConfig(
+            *config.get("PUT", DEFAULT_LATENCY_ENTRY))
+
+    def get_by_action(self, action):
+        """Return the corresponding LatencyConfig for the action passed in.
+
+        Args:
+            actions (str): Action as a string. (Options can be found on the
+                           ACTIONS global obect.
+        """
+        if action == ACTIONS.DELETE:
+            return self.delete_latencies
+
+        elif action == ACTIONS.GET:
+            return self.get_latencies
+
+        elif action == ACTIONS.PUT:
+            return self.put_latencies
+
+
+class LatencyConfig(object):
+    """Datastore latency configuration object.
+
+    Properties:
+        latencies (Choice): Choice object of datastore latencies
+        latency_rate (float): Latency Rate (should be between 0.00 and 1.00)
+    """
+
+    def __init__(self, latencies, latency_rate):
+        """Initialize the LatencyConfig object setting the latencies and
+        latency_rate to the passed in values. The latencies are converted to a
+        Choice object.
+
+        Args:
+            latencies (dict): Dictionary of choices (keys) and propability
+                              weights (values)
+            latency_rate (float): Latency rate value between 0.00 and 1.00
+        """
+        self.latencies = Choice(latencies.values(), latencies.keys())
+        self.latency_rate = latency_rate

--- a/gchaos/errors.py
+++ b/gchaos/errors.py
@@ -23,3 +23,7 @@
 
 class ChaosException(Exception):
     """A Chaos Exception."""
+
+
+class InvalidLatencyException(Exception):
+    """An invalid latency exception."""

--- a/gchaos/gae/datastore/errors.py
+++ b/gchaos/gae/datastore/errors.py
@@ -22,18 +22,9 @@
 
 import logging
 
-from collections import defaultdict
-
-
-from itertools import ifilter
-from itertools import imap
-
 from gchaos.chance import roll
 from gchaos.errors import ChaosException
-from gchaos.gae.datastore.actions import ACTIONS
-from gchaos.settings import DATASTORE_STUB
 from gchaos.utils import get_func_info_for_path
-
 
 
 def trigger(error_config):

--- a/gchaos/gae/datastore/hook.py
+++ b/gchaos/gae/datastore/hook.py
@@ -1,0 +1,124 @@
+# MIT License
+
+# Copyright (c) 2017 Real Kinetic
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+
+from gchaos.settings import DATASTORE_STUB
+from gchaos.gae.datastore.actions import ACTIONS
+from gchaos.gae.datastore.errors import trigger as trigger_errors
+
+
+DATSTORE_HOOK_INSTALLED = False
+
+
+def install_hook(config):
+    """Install the datastore hook with binding the datastore config to be
+    checked when calls come in.
+
+    Args:
+        config (gchaos.config.hydrate.DatastoreConfig):
+            Datastore configuration
+
+    Return:
+        None
+    """
+    from google.appengine.api.apiproxy_stub_map import apiproxy
+
+    global DATSTORE_HOOK_INSTALLED
+
+    if DATSTORE_HOOK_INSTALLED:
+        return
+
+    apiproxy.GetPreCallHooks().Append(
+        'gchaos_datastore_hooks', hook_wrapper(config), DATASTORE_STUB)
+
+    DATSTORE_HOOK_INSTALLED = True
+
+
+def hook_wrapper(config):
+    """The function that wraps all datastore calls. And will trigger the action
+    if the service is the datastore stub.
+
+    Args:
+        config (gchaos.config.hydrate.{ErrorsConfig|LatenciesConfig|):
+            Datastore errors or latencies configuration
+
+    Returns:
+        func
+    """
+
+    def wrap(service, name, request, response):
+        """Called before hitting the datastore stub."""
+        assert service == DATASTORE_STUB
+
+        trigger_action(name, config)
+
+    return wrap
+
+
+def trigger_action(name, config):
+    """If the service is a datastore action that we track get the errors or
+    latencies for the action from the config and if those exist pass them on to
+    the trigger functions.
+
+    Args:
+        name (str): Google service action
+        config (gchaos.config.hydrate.DatastoreConfig):
+            Datastore configuration.
+
+    Return:
+        None
+    """
+    uname = name.upper()
+
+    if uname not in ACTIONS.all():
+        logging.info(
+            "Action is not in our tracked actions {0}".format(uname))
+        return
+
+    # Errors
+    get_config_and_trigger(uname, config.errors, trigger_errors)
+
+    # Latencies
+    # get_config_and_trigger(uname, config.latencies)
+
+
+def get_config_and_trigger(service_name, config, trigger_func):
+    """Load the specific configuration from the config for the service. If a
+    configuration exists for the service trigger the function passed in with
+    that configuration.
+
+    Args:
+        service_name (string): Name of the services (should be in ACTIONS)
+        config (gchaos.config.hydrate.{ErrorConfig|LatencyConfig}:
+            Datastore Configuration
+        trigger_func (func): The function to trigger which takes the config
+
+    Return:
+        None
+    """
+    # Load each specific config for the action off errors and latencies
+    loaded_config = config.get_by_action(service_name)
+
+    # Trigger the functions for each errors and latencies if the config exists.
+    if loaded_config:
+        trigger_func(loaded_config)

--- a/gchaos/gae/datastore/hook.py
+++ b/gchaos/gae/datastore/hook.py
@@ -24,6 +24,7 @@ import logging
 
 from gchaos.settings import DATASTORE_STUB
 from gchaos.gae.datastore.actions import ACTIONS
+from gchaos.gae.datastore.latency import trigger as trigger_latency
 from gchaos.gae.datastore.errors import trigger as trigger_errors
 
 
@@ -95,11 +96,27 @@ def trigger_action(name, config):
             "Action is not in our tracked actions {0}".format(uname))
         return
 
+    _trigger_actions(uname, config)
+
+
+def _trigger_actions(name, config):
+    """Call the trigger functions for errors and latencies.
+
+    Args:
+        name (str): Google service action
+        config (gchaos.config.hydrate.DatastoreConfig):
+            Datastore configuration.
+
+    Return:
+        None
+    """
     # Errors
-    get_config_and_trigger(uname, config.errors, trigger_errors)
+    if config.errors.enabled:
+        get_config_and_trigger(name, config.errors, trigger_errors)
 
     # Latencies
-    # get_config_and_trigger(uname, config.latencies)
+    if config.latency.enabled:
+        get_config_and_trigger(name, config.latency, trigger_latency)
 
 
 def get_config_and_trigger(service_name, config, trigger_func):

--- a/gchaos/gae/datastore/latency.py
+++ b/gchaos/gae/datastore/latency.py
@@ -20,15 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
 import logging
 
 from collections import defaultdict
+import random
 
 
 from itertools import ifilter
 from itertools import imap
 
-from gchaos.chance import roll
 from gchaos.errors import ChaosException
 from gchaos.gae.datastore.actions import ACTIONS
 from gchaos.settings import DATASTORE_STUB
@@ -49,7 +50,14 @@ def trigger(error_config):
     Return:
         None
     """
-    if not roll(error_config.error_rate):
+    chance = _get_chance()
+
+    logging.info("ERROR RATE {0} AND CHANCE {1}".format(
+        error_config.error_rate, chance))
+
+    if error_config.error_rate < chance:
+        # TODO: Look at using inspect to insert this definition will always
+        # work.
         return
 
     if error_config.errors.choices and error_config.errors.weights:
@@ -59,3 +67,13 @@ def trigger(error_config):
         raise error_info.func()
 
     raise ChaosException("Raising Chaos!")
+
+
+def _get_chance():
+    """Generate a random number and return it.
+
+    Return:
+        int
+    """
+    random.seed()
+    return random.random()

--- a/gchaos/gae/datastore/latency.py
+++ b/gchaos/gae/datastore/latency.py
@@ -53,7 +53,7 @@ def trigger(latency_config):
 
 def stall(latency):
     """Based off the latency stall for that long. The latency is a tuple if only
-    one value is provided then stall for exactly that long. If to values are
+    one value is provided then stall for exactly that long. If two values are
     provided then stall for a random choice between those values.
 
     Args:
@@ -110,8 +110,6 @@ def get_stall_time_from_range(latency):
     if max_ < min_:
         raise InvalidLatencyException(latency)
 
-    random.seed()
-    
     return randint(min_, max_)
 
 

--- a/gchaos/gae/datastore/latency.py
+++ b/gchaos/gae/datastore/latency.py
@@ -111,7 +111,7 @@ def get_stall_time_from_range(latency):
         raise InvalidLatencyException(latency)
 
     random.seed()
-    # TODO: Ensure second value is greater
+    
     return randint(min_, max_)
 
 

--- a/gchaos/install.py
+++ b/gchaos/install.py
@@ -22,6 +22,7 @@
 
 
 import logging
+import random
 
 from gchaos.config import CHAOS_CONFIG
 from gchaos.gae.datastore import install_datastore_hooks
@@ -41,5 +42,6 @@ def install_chaos(config=None):
 
     # TODO: Create a to dict method on the ChaosConfig object.
     # logging.info("CHAOS: Default Chaos Config: {0}".format(config))
+    random.seed()
 
     install_datastore_hooks(config.datastore)

--- a/tests/config/test_hydrate.py
+++ b/tests/config/test_hydrate.py
@@ -51,7 +51,6 @@ class HydrateDataStoreConfigTests(unittest.TestCase):
 
 def verify_datastore_config(datastore_config, runner):
     runner.assertEqual(datastore_config.enabled, True)
-    runner.assertIsNone(datastore_config.latency)
 
     # DELETE ERRORS
     runner.assertEqual(datastore_config.errors.delete_errors.error_rate, 0.05)
@@ -85,3 +84,41 @@ def verify_datastore_config(datastore_config, runner):
         datastore_config.errors.put_errors.errors.weights,
         DS_CONFIG["errors"]["PUT"][0].values()
     )
+
+    # DELETE LATENCIES
+    runner.assertEqual(datastore_config.latency.delete_latencies.latency_rate,
+                       0.05)
+    runner.assertEqual(
+        datastore_config.latency.delete_latencies.latencies.choices,
+        DS_CONFIG["latency"]["DELETE"][0].keys()
+    )
+    runner.assertEqual(
+        datastore_config.latency.delete_latencies.latencies.weights,
+        DS_CONFIG["latency"]["DELETE"][0].values()
+    )
+
+    # GET LATENCIES
+    runner.assertEqual(datastore_config.latency.get_latencies.latency_rate,
+                       0.01)
+    runner.assertEqual(
+        datastore_config.latency.get_latencies.latencies.choices,
+        DS_CONFIG["latency"]["GET"][0].keys()
+    )
+    runner.assertEqual(
+        datastore_config.latency.get_latencies.latencies.weights,
+        DS_CONFIG["latency"]["GET"][0].values()
+    )
+
+    # PUT LATENCIES
+    runner.assertEqual(datastore_config.latency.put_latencies.latency_rate,
+                       0.02)
+    runner.assertEqual(
+        datastore_config.latency.put_latencies.latencies.choices,
+        DS_CONFIG["latency"]["PUT"][0].keys()
+    )
+    runner.assertEqual(
+        datastore_config.latency.put_latencies.latencies.weights,
+        DS_CONFIG["latency"]["PUT"][0].values()
+    )
+
+

--- a/tests/config/test_hydrate.py
+++ b/tests/config/test_hydrate.py
@@ -52,73 +52,65 @@ class HydrateDataStoreConfigTests(unittest.TestCase):
 def verify_datastore_config(datastore_config, runner):
     runner.assertEqual(datastore_config.enabled, True)
 
+    runner.assertTrue(datastore_config.errors.enabled)
+
     # DELETE ERRORS
     runner.assertEqual(datastore_config.errors.delete_errors.error_rate, 0.05)
     runner.assertEqual(
         datastore_config.errors.delete_errors.errors.choices,
-        DS_CONFIG["errors"]["DELETE"][0].keys()
+        DS_CONFIG["errors"][1]["DELETE"][0].keys()
     )
     runner.assertEqual(
         datastore_config.errors.delete_errors.errors.weights,
-        DS_CONFIG["errors"]["DELETE"][0].values()
+        DS_CONFIG["errors"][1]["DELETE"][0].values()
     )
 
     # GET ERRORS
     runner.assertEqual(datastore_config.errors.get_errors.error_rate, 0.01)
     runner.assertEqual(
         datastore_config.errors.get_errors.errors.choices,
-        DS_CONFIG["errors"]["GET"][0].keys()
+        DS_CONFIG["errors"][1]["GET"][0].keys()
     )
     runner.assertEqual(
         datastore_config.errors.get_errors.errors.weights,
-        DS_CONFIG["errors"]["GET"][0].values()
+        DS_CONFIG["errors"][1]["GET"][0].values()
     )
 
     # PUT ERRORS
     runner.assertEqual(datastore_config.errors.put_errors.error_rate, 0.02)
     runner.assertEqual(
         datastore_config.errors.put_errors.errors.choices,
-        DS_CONFIG["errors"]["PUT"][0].keys()
+        DS_CONFIG["errors"][1]["PUT"][0].keys()
     )
     runner.assertEqual(
         datastore_config.errors.put_errors.errors.weights,
-        DS_CONFIG["errors"]["PUT"][0].values()
+        DS_CONFIG["errors"][1]["PUT"][0].values()
     )
+
+    runner.assertTrue(datastore_config.latency.enabled)
 
     # DELETE LATENCIES
     runner.assertEqual(datastore_config.latency.delete_latencies.latency_rate,
                        0.05)
     runner.assertEqual(
-        datastore_config.latency.delete_latencies.latencies.choices,
-        DS_CONFIG["latency"]["DELETE"][0].keys()
-    )
-    runner.assertEqual(
-        datastore_config.latency.delete_latencies.latencies.weights,
-        DS_CONFIG["latency"]["DELETE"][0].values()
+        datastore_config.latency.delete_latencies.latency,
+        DS_CONFIG["latency"][1]["DELETE"][0]
     )
 
     # GET LATENCIES
     runner.assertEqual(datastore_config.latency.get_latencies.latency_rate,
                        0.01)
     runner.assertEqual(
-        datastore_config.latency.get_latencies.latencies.choices,
-        DS_CONFIG["latency"]["GET"][0].keys()
-    )
-    runner.assertEqual(
-        datastore_config.latency.get_latencies.latencies.weights,
-        DS_CONFIG["latency"]["GET"][0].values()
+        datastore_config.latency.get_latencies.latency,
+        DS_CONFIG["latency"][1]["GET"][0]
     )
 
     # PUT LATENCIES
     runner.assertEqual(datastore_config.latency.put_latencies.latency_rate,
                        0.02)
     runner.assertEqual(
-        datastore_config.latency.put_latencies.latencies.choices,
-        DS_CONFIG["latency"]["PUT"][0].keys()
-    )
-    runner.assertEqual(
-        datastore_config.latency.put_latencies.latencies.weights,
-        DS_CONFIG["latency"]["PUT"][0].values()
+        datastore_config.latency.put_latencies.latency,
+        DS_CONFIG["latency"][1]["PUT"][0]
     )
 
 

--- a/tests/gae/datastore/test_hooks.py
+++ b/tests/gae/datastore/test_hooks.py
@@ -1,0 +1,107 @@
+# MIT License
+
+# Copyright (c) 2017 Real Kinetic
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import unittest
+
+from mock import MagicMock
+from mock import patch
+
+from gchaos.config import CHAOS_CONFIG
+from gchaos.gae.datastore.actions import ACTIONS
+from gchaos.gae.datastore.errors import trigger as trigger_errors
+from gchaos.gae.datastore.hook import get_config_and_trigger
+from gchaos.gae.datastore.hook import trigger_action
+
+
+@patch('gchaos.gae.datastore.hook.get_config_and_trigger')
+class TriggerActionErrorTests(unittest.TestCase):
+
+    def test_name_not_in_actions(self, get_config_and_trigger_mock):
+        """Ensure if the name is not in the actions that no subsequent calls
+        are made.
+        """
+        name = "foo"
+
+        ds_config = CHAOS_CONFIG.datastore
+
+        trigger_action(name, ds_config)
+
+        get_config_and_trigger_mock.assert_not_called()
+
+    def test_name_in_actions(self, get_config_and_trigger_mock):
+        """Ensure if the name is in the actions that subsequent calls are made.
+        """
+        name = ACTIONS.GET
+
+        ds_config = CHAOS_CONFIG.datastore
+
+        trigger_action(name, ds_config)
+
+        get_config_and_trigger_mock.assert_called_once_with(
+            name, ds_config.errors, trigger_errors)
+
+
+class GetConfigAndTriggerTestCase(unittest.TestCase):
+
+    def test_no_config(self):
+        """Ensure if the action doesn't return a config doesn't trigger."""
+        name = "foo"
+
+        trigger_func = MagicMock()
+
+        error_config = CHAOS_CONFIG.datastore.errors
+        error_config.get_by_action = MagicMock(return_value=None)
+
+        get_config_and_trigger(name, error_config, trigger_func)
+
+        error_config.get_by_action.assert_called_once_with(name)
+        trigger_func.assert_not_called()
+
+    def test_error_config_exists(self):
+        """Ensure if the action does return a config for errors does trigger."""
+        name = "foo"
+
+        trigger_func = MagicMock()
+
+        error_config = CHAOS_CONFIG.datastore.errors
+        error_config.get_by_action = MagicMock(
+            return_value=error_config.get_errors)
+
+        get_config_and_trigger(name, error_config, trigger_func)
+
+        error_config.get_by_action.assert_called_once_with(name)
+        trigger_func.assert_called_once_with(error_config.get_errors)
+
+    def test_latency_config_exists(self):
+        """Ensure if the action does return a config for latency does trigger."""
+        name = "foo"
+
+        trigger_func = MagicMock()
+
+        latency_config = CHAOS_CONFIG.datastore.latency
+        latency_config.get_by_action = MagicMock(
+            return_value=latency_config.get_latencies)
+
+        get_config_and_trigger(name, latency_config, trigger_func)
+
+        latency_config.get_by_action.assert_called_once_with(name)
+        trigger_func.assert_called_once_with(latency_config.get_latencies)

--- a/tests/gae/datastore/test_latency.py
+++ b/tests/gae/datastore/test_latency.py
@@ -1,0 +1,143 @@
+# MIT License
+
+# Copyright (c) 2017 Real Kinetic
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import unittest
+
+from mock import MagicMock
+from mock import patch
+
+from gchaos.config import CHAOS_CONFIG
+from gchaos.config.hydrate import LatencyConfig
+from gchaos.errors import InvalidLatencyException
+
+from gchaos.gae.datastore.actions import ACTIONS
+from gchaos.gae.datastore.latency import get_stall_time_from_range
+from gchaos.gae.datastore.latency import stall
+from gchaos.gae.datastore.latency import _stall
+from gchaos.gae.datastore.latency import trigger
+
+
+@patch('gchaos.gae.datastore.latency.roll')
+class TriggerTestCase(unittest.TestCase):
+
+    @patch('gchaos.gae.datastore.latency.stall')
+    def test_latency_rate_less_than_chance(self, stall, roll):
+        """Ensure when the chance is greater than the latency rate that the
+        stall method is not called.
+        """
+        roll.return_value = False
+
+        config = LatencyConfig(None, 0.01)
+
+        trigger(config)
+
+        roll.assert_called_once_with(0.01)
+        stall.assert_not_called()
+
+
+@patch('gchaos.gae.datastore.latency._stall')
+class StallTestCase(unittest.TestCase):
+
+    def test_latency_not_configured(self, _stall_mock):
+        """Ensure when no latency is set on the config that no other actions
+        are triggered.
+        """
+        stall(None)
+
+        _stall_mock.assert_not_called()
+
+    def test_latency_configured_with_single_value(self, _stall_mock):
+        """Ensure when a single value latency is set on the config that the
+        _stall function is called with that.
+        """
+        stall((1000,))
+
+        _stall_mock.assert_called_once_with(1000)
+
+    def test_latency_configured_with_int_value(self, _stall_mock):
+        """Ensure when a single int value latency is set on the config that the
+        _stall function is called with that.
+        """
+        stall(1000)
+
+        _stall_mock.assert_called_once_with(1000)
+
+    def test_latency_configured_with_bad_value(self, _stall_mock):
+        """Ensure when a bad latency value is set on the config that an
+        InvalidLatencyException is raised.
+        """
+        self.assertRaises(InvalidLatencyException, stall, "a")
+
+        _stall_mock.assert_not_called()
+
+    @patch('gchaos.gae.datastore.latency.get_stall_time_from_range')
+    def test_latency_configured_with_rage(self, range_mock, _stall_mock):
+        """Ensure when a range latency is set on the config that the _stall
+        function is called with the result of getting the value from the range.
+        """
+        range_mock.return_value = 2000
+
+        stall((1000, 3000))
+
+        _stall_mock.assert_called_once_with(2000)
+        range_mock.assert_called_once_with((1000, 3000))
+
+
+class GetStallTimeFromRangeTestCase(unittest.TestCase):
+
+    def test_latency_not_a_2_value_tuple(self):
+        """Ensure if latency is not a 2 value tuple that an
+        InvalidLatencyException is raised.
+        """
+        self.assertRaises(
+            InvalidLatencyException, get_stall_time_from_range, (1, 2, 3))
+
+    def test_latency_2nd_value_not_greater_than_first_value(self):
+        """Ensure if the latency tuple has a second value less than the first
+        that an InvalidLatencyException is raised.
+        """
+        self.assertRaises(
+            InvalidLatencyException, get_stall_time_from_range, (3, 2))
+
+    @patch('gchaos.gae.datastore.latency.randint')
+    def test_latency_is_valid(self, randint):
+        """Ensure if the latency is valid that it calls into randint and returns
+        it's result.
+        """
+        randint.return_value = 2000
+
+        result = get_stall_time_from_range((1000, 3000))
+
+        self.assertEqual(result, 2000)
+
+        randint.assert_called_once_with(1000, 3000)
+
+
+class StallSleepTestCase(unittest.TestCase):
+
+    @patch('gchaos.gae.datastore.latency.sleep')
+    def test_stall(self, sleep):
+        """Ensure sleep is called with the correct value."""
+        _stall(1500)
+
+        sleep.assert_called_once_with(1.5)

--- a/tests/test_chance.py
+++ b/tests/test_chance.py
@@ -1,0 +1,65 @@
+# MIT License
+
+# Copyright (c) 2017 Real Kinetic
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import unittest
+
+from mock import patch
+
+from gchaos.chance import roll
+
+
+@patch('gchaos.chance._get_chance')
+class RollTestCase(unittest.TestCase):
+
+    def test_value_is_less_than_chance(self, get_chance_mock):
+        """Ensure if the value is less than the chance that it returns false."""
+        get_chance_mock.return_value = 0.99
+        value = 0.01
+
+        result = roll(value)
+
+        self.assertFalse(result)
+
+        get_chance_mock.assert_called_once_with()
+
+    def test_value_is_greater_than_chance(self, get_chance_mock):
+        """Ensure if the value is greater than the chance that it returns true."""
+        get_chance_mock.return_value = 0.01
+        value = 0.99
+
+        result = roll(value)
+
+        self.assertTrue(result)
+
+        get_chance_mock.assert_called_once_with()
+
+    def test_value_is_equal_to_chance(self, get_chance_mock):
+        """Ensure if the value is equal to the chance that it returns true."""
+        get_chance_mock.return_value = 0.50
+        value = 0.50
+
+        result = roll(value)
+
+        self.assertTrue(result)
+
+        get_chance_mock.assert_called_once_with()


### PR DESCRIPTION
The datastore hook will now also leverage the latency configuration if
its set to insert latency spikes based off that configuration.

Also updated the README documentation to include the latency docs. As
well as some other quick tweaks to the README.

The datastore configuration also needed updating:
- Add LatencyConfig and LatenciesConfig objects in hydrate for storing
latency configurations in memory.
- Add a default latency configuration to part of the datastore configration.
- Also added flags for latency and errors so you can do them optionally

On the way to supporting latency we also refactored the hooks
- Move some of the more reusable error hook code into it's own hook
module.
- This includes moving the chance/roll logic out to it's own module under
gchaos and exposing a roll function in that module.

@RealKinetic/devs 